### PR TITLE
PR5679 Review

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2966,7 +2966,7 @@ export default class BattleScene extends SceneBase {
       if (
         modifier instanceof PokemonHeldItemModifier &&
         !isNullOrUndefined(modifier.getSpecies()) &&
-        !this.getPokemonById((modifier as PokemonHeldItemModifier).pokemonId)?.hasSpecies(modifier.getSpecies()!)
+        !this.getPokemonById(modifier.pokemonId)?.hasSpecies(modifier.getSpecies()!)
       ) {
         modifiers.splice(m--, 1);
       }


### PR DESCRIPTION
- Convert `EvoCondKey` enum to `const` object

- Use early returns in `SpeciesEvolutionCondition#description` and `SpeciesFormEvolution#description`

- Replace `!!x.find` with `x.some` and `y.indexOf() > -1` with `y.includes()`

- Implement `coerceArray`

- Fix Shelmet evolution condition checking for Shelmet and not Karrablast

- Remove unnecessary type casting in `battle-scene.ts`